### PR TITLE
Switched to a time lock

### DIFF
--- a/merkle-store-hardhat/contracts/UpgradableMerkleStoreV2.sol
+++ b/merkle-store-hardhat/contracts/UpgradableMerkleStoreV2.sol
@@ -24,15 +24,25 @@ contract UpgradableMerkleStoreV2 is
         keccak256("OPERATIONAL_ADMIN_ROLE");
 
     // Events
+
+    /// idx -> Provided index for look-ups
+    /// merkleRoot -> The Merkle root of the data
+    /// lockAt -> Timestamp of when will be locked
+    /// metadata -> Any additional data stored with the merkle tree
     event NewRootSubmission(
+        bytes32 indexed idx,
         bytes32 indexed merkleRoot,
-        uint256 indexed lock_at,
-        string data,
+        uint256 indexed lockAt,
         string metadata
     );
+
+    /// idx -> Provided index for look-ups
+    /// merkleRoot -> The Merkle root of the data
+    /// lockAt -> Timestamp of when will be locked, 0 implies nothing
+    /// metadata -> The new, updated metadata.
     event RootMetadataModification(
-        bytes32 indexed merkleRoot,
-        uint256 indexed lock_at,
+        bytes32 indexed idx,
+        uint256 indexed lockAt,
         string metadata
     );
 
@@ -44,7 +54,7 @@ contract UpgradableMerkleStoreV2 is
         /// with this tree.
         string metadata;
         /// Lock timestamp, 0 implies unlocked and no future lock
-        uint256 lock_at;
+        uint256 lockAt;
         /// Mutable metadata, should be used for things that can change depending on
         /// how it runs.
         uint256 submittedOn;
@@ -87,86 +97,95 @@ contract UpgradableMerkleStoreV2 is
     ) internal override onlyRole(UPGRADE_ADMIN_ROLE) {}
 
     /// @notice Submit a new Merkle root with metadata
+    /// @param idx An identifying index
     /// @param merkleRoot The merkle root of the tree submission
     /// @param metadata Any metadata stored
-    /// @param lock_at When the data should be locked.  If timestamp is from before block.timestamp, use block.timestamp instead
+    /// @param lockAt When the data should be locked.  If timestamp is from before block.timestamp, use block.timestamp instead
     /// @return hashedMerkleRoot Returns the hashed merkle root
     function submitNewMerkleRootWithMetadata(
+        bytes32 idx,
         bytes32 merkleRoot,
         string calldata metadata,
-        uint256 lock_at
+        uint256 lockAt
     ) external onlyRole(OPERATIONAL_ADMIN_ROLE) returns (bytes32) {
+
+        
+        mapping(bytes32 => Submission)
+            storage merkleRoots = _getMerkleRootsStorage();
+
+        require(merkleRoots[idx].submittedOn != 0, "Cannot submitNewMerkleRoot with given Idx, already taken.");
+
         // Increment root nonce
         uint256 rootNonce = StorageSlot.getUint256Slot(_ROOT_NONCE_SLOT).value +
             1;
         StorageSlot.getUint256Slot(_ROOT_NONCE_SLOT).value = rootNonce;
 
-        if (lock_at < block.timestamp) {
-            lock_at = block.timestamp;
+        // If lock is not 0, and it is before the block timestamp, we should update it
+        // so that it is the same as now
+        if (lockAt != 0 && lockAt < block.timestamp) {
+            lockAt = block.timestamp;
         }
 
         // Store new submission
-        mapping(bytes32 => Submission)
-            storage merkleRoots = _getMerkleRootsStorage();
-        merkleRoots[merkleRoot] = Submission(
+        merkleRoots[idx] = Submission(
             merkleRoot,
             metadata,
-            lock_at,
+            lockAt,
             block.number,
             block.number
         );
 
-        emit NewRootSubmission(merkleRoot, lock_at, metadata, metadata);
+        emit NewRootSubmission(idx, merkleRoot, lockAt, metadata);
         return sha256(abi.encodePacked(merkleRoot));
     }
 
     /// @notice Update metadata & lock for an existing Merkle root
-    /// @param merkleRoot The merkle root of the tree we look up
+    /// @param idx The index of the submission
     /// @param newMetadata Additional data (JSON?) stored with the tree.
-    /// @param lock_at Timestamp of when it should be locked.
+    /// @param lockAt Timestamp of when the metadata should be locked
     /// @return submission Returns the updated submission
     function updateMetadataOnMerkleRootHash(
-        bytes32 merkleRoot,
+        bytes32 idx,
         string calldata newMetadata,
-        uint256 lock_at
+        uint256 lockAt
     ) external onlyRole(OPERATIONAL_ADMIN_ROLE) returns (Submission memory) {
         mapping(bytes32 => Submission)
             storage merkleRoots = _getMerkleRootsStorage();
-        Submission storage prevSubmission = merkleRoots[merkleRoot];
+        Submission storage prevSubmission = merkleRoots[idx];
 
-        require(prevSubmission.lock_at > block.timestamp, "Submission is locked");
+        require(prevSubmission.lockAt > block.timestamp, "Submission is locked");
         require(prevSubmission.submittedOn != 0, "Submission does not exist");
 
-        if (lock_at < block.timestamp) {
-            lock_at = block.timestamp;
+        if (lockAt < block.timestamp) {
+            lockAt = block.timestamp;
         }
 
         prevSubmission.metadata = newMetadata;
-        prevSubmission.lock_at = lock_at;
+        prevSubmission.lockAt = lockAt;
         prevSubmission.updatedOn = block.number;
 
-        emit RootMetadataModification(merkleRoot, lock_at, newMetadata);
+        emit RootMetadataModification(idx,  lockAt, newMetadata);
         return prevSubmission;
     }
 
     /// @notice Update lock on the data in the hash
-    /// @param merkleRoot The merkle root of the tree we look up to lock
+    /// @param idx Index used for a tree
     /// @return Submission Returns the submission in its final, locked state.
     function lockMetadataOnMerkleRootHash(
-        bytes32 merkleRoot
+        bytes32 idx
     ) external onlyRole(OPERATIONAL_ADMIN_ROLE) returns (Submission memory) {
         mapping(bytes32 => Submission)
             storage merkleRoots = _getMerkleRootsStorage();
-        Submission storage prevSubmission = merkleRoots[merkleRoot];
+        Submission storage prevSubmission = merkleRoots[idx];
 
-        require(prevSubmission.lock_at > block.timestamp, "Submission is already locked");
+        require(prevSubmission.lockAt > block.timestamp, "Submission is already locked");
         require(prevSubmission.submittedOn != 0, "Submission does not exist");
 
-        prevSubmission.lock_at = block.timestamp;
+        prevSubmission.lockAt = block.timestamp;
         prevSubmission.updatedOn = block.number;
 
         emit RootMetadataModification(
-            merkleRoot,
+            idx,
             block.timestamp,
             prevSubmission.metadata
         );
@@ -174,14 +193,14 @@ contract UpgradableMerkleStoreV2 is
     }
 
     /// @notice Get submission details by index
-    /// @param merkleRoot Returns the Submission of a merkle tree
+    /// @param idx Index used for lookup of tree
     /// @return Submission The submission for a given merkleRoot
     function getMerkleRootOnHash(
-        bytes32 merkleRoot
+        bytes32 idx
     ) external view returns (Submission memory) {
         mapping(bytes32 => Submission)
             storage merkleRoots = _getMerkleRootsStorage();
-        return merkleRoots[merkleRoot];
+        return merkleRoots[idx];
     }
 
     /// @notice Get the total number of Merkle roots submitted


### PR DESCRIPTION
Switched from a simple bool to a timelock to allow future locks to be set

@syed-bcw can you make sure what I did makes sense?  I made sure that if the lock was for before now, it switches to using the block.timestamp, to make sure that if the request is submitted but it is not committed to the chain until after the provided timestamp, that it updates to the moment it was truly locked, does this make sense?